### PR TITLE
refactor!: maybe map status code now returns input in on-else

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,72 @@
+## 1.1.0
+
+Contains **breaking changes** in `maybeMapStatusCode` method on `num`. Please follow migration guide below.
+
+- refactor!: orElse parameter in maybeMapStatusCode now returns input value in order to handle this unregistered status code.
+
+- docs: updated documentation of breaking update.
+- docs: added topics to pubspec.yaml.
+- chore: updated sdk upper-bound to 4.0.0.
+- refactor: replaced deprecated fields in analysis_options.yaml with new ones.
+
+Since `maybeMapStatusCode` is now returns input value, you will have to adjust your existing code, for example:
+
+Replace from:
+
+```dart
+...
+final statusCode = response.statusCode;
+...
+statusCode.maybeMapStatusCode(
+    orElse: () => handleUnregisteredStatusCode(statusCode),
+    isSuccess: handleSuccessStatusCode,
+    ...
+);
+...
+```
+
+Use this instead:
+
+```dart
+...
+final statusCode = response.statusCode;
+...
+statusCode.maybeMapStatusCode(
+    orElse: handleUnregisteredStatusCode,
+    isSuccess: handleSuccessStatusCode,
+    ...
+);
+...
+```
+
+Or if you are using tear-off syntax, replace:
+
+```dart
+...
+final statusCode = response.statusCode;
+...
+statusCode.maybeMapStatusCode(
+    orElse: handleUnregisteredStatusCode,
+    isSuccess: handleSuccessStatusCode,
+    ...
+);
+...
+```
+
+With this instead:
+
+```dart
+...
+final statusCode = response.statusCode;
+...
+statusCode.maybeMapStatusCode(
+    orElse: (_) => handleUnregisteredStatusCode(),
+    isSuccess: handleSuccessStatusCode,
+    ...
+);
+...
+```
+
 ## 1.0.6
 
 - docs: fixed contribution guidelines reference link.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Contains **breaking changes** in `maybeMapStatusCode` method on `num`. Please fo
 - chore: updated sdk upper-bound to 4.0.0.
 - refactor: replaced deprecated fields in analysis_options.yaml with new ones.
 
-Since `maybeMapStatusCode` is now returns input value, you will have to adjust your existing code, for example:
+Since `maybeMapStatusCode` now returns input value, you will have to adjust your existing code, for example:
 
 Replace from:
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ To use this package, add `functional_status_codes` as a dependency in your `pubs
 
 ```yaml
 dependencies:
-  functional_status_codes: ^1.0.6
+  functional_status_codes: ^1.1.0
 ```
 
 Then import the package in your Dart code:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -15,9 +15,10 @@ analyzer:
     # Coverage
     - "test/.test_coverage.dart"
 
-  strong-mode:
-    implicit-casts: false
-    implicit-dynamic: false
+  language:
+    strict-casts: true
+    strict-inference: true
+    strict-raw-types: true
 
   errors:
     # Info
@@ -90,6 +91,7 @@ dart_code_metrics:
     - avoid-missing-enum-constant-in-map: true
     - avoid-non-ascii-symbols: true
     - avoid-non-null-assertion: true
+    - avoid-substring: true
     - avoid-throw-in-catch-block: true
     - avoid-unnecessary-conditionals: true
     - avoid-unnecessary-type-assertions: true
@@ -270,7 +272,6 @@ linter:
     prefer_collection_literals: true
     prefer_conditional_assignment: true
     prefer_contains: true
-    prefer_equal_for_default_values: true
     prefer_final_fields: true
     prefer_for_elements_to_map_fromIterable: true
     prefer_generic_function_type_aliases: true

--- a/lib/src/num_status_code_extension.dart
+++ b/lib/src/num_status_code_extension.dart
@@ -170,17 +170,17 @@ extension NumStatusCodeExtension<T extends num> on T? {
   ///
   /// ```dart
   /// 200.maybeMapStatusCode(
-  ///   orElse: () => 'unknown',
+  ///   orElse: (value) => 'unregistered code: $value',
   ///   isSuccess: (code) => 'success',
   /// ); // Returns 'success'
   ///
   /// 600.maybeMapStatusCode(
-  ///   orElse: () => 'unknown',
+  ///   orElse: (value) => 'unregistered code: $value',
   ///   isSuccess: (code) => 'success',
-  /// ); // Returns 'unknown'
+  /// ); // Returns 'unregistered code: 600'
   /// ```
   R maybeMapStatusCode<R>({
-    required R Function() orElse,
+    required R Function(T? number) orElse,
     R Function(T isStatusCode)? isStatusCode,
     R Function(T isInformational)? isInformational,
     R Function(T isSuccess)? isSuccess,
@@ -190,7 +190,7 @@ extension NumStatusCodeExtension<T extends num> on T? {
   }) {
     final thisValue = this;
     if (thisValue == null) {
-      return orElse();
+      return orElse(thisValue);
     }
     if (thisValue.isStatusCode && isStatusCode != null) {
       return isStatusCode(thisValue);
@@ -205,7 +205,7 @@ extension NumStatusCodeExtension<T extends num> on T? {
     } else if (thisValue.isServerError && isServerError != null) {
       return isServerError(thisValue);
     } else {
-      return orElse();
+      return orElse(thisValue);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,24 @@
-version: 1.0.6
+version: 1.1.0
 name: functional_status_codes
 description: This package offers a functional approach to handling HTTP status codes.
 maintainer: Roman Cinis
 repository: https://github.com/tsinis/functional_status_codes
 issue_tracker: https://github.com/tsinis/functional_status_codes/issues
+topics:
+ - status-codes
+ - status-code
+ - http
+ - https
 
 environment:
-  sdk: '>=2.17.0 <3.0.0'
+  sdk: '>=2.17.0 <4.0.0'
 
 dev_dependencies:
   build_runner: ^2.3.3 # From Google
-  dart_code_metrics: ^5.6.0 # Flutter Favorite
+  dart_code_metrics: ^5.7.3 # Flutter Favorite
   lints: ^2.0.1 # From Google
-  pana: ^0.21.26 # From Google
-  test: ^1.23.1 # From Google
+  pana: ^0.21.31 # From Google
+  test: ^1.24.2 # From Google
 
 screenshots:
   - description: 'Good/Bad Comparison'

--- a/test/src/num_status_code_extension_test.dart
+++ b/test/src/num_status_code_extension_test.dart
@@ -250,12 +250,12 @@ void main() => group('NumStatusCodeExtension', () {
               isRedirection: (value) => value,
               isClientError: (value) => value,
               isServerError: (value) => value,
-              orElse: () => elseValue,
+              orElse: (_) => elseValue,
             );
 
         for (final number in globalWrongCases) {
           test(
-            'should throw orElse value for $number',
+            'should return orElse value for $number',
             () => expect(maybeMapCode(number), elseValue),
           );
         }
@@ -265,7 +265,7 @@ void main() => group('NumStatusCodeExtension', () {
           () => expect(
             testValue.maybeMapStatusCode(
               isStatusCode: (value) => value,
-              orElse: () => null,
+              orElse: (value) => value,
             ),
             testValue,
           ),


### PR DESCRIPTION
<!--

  Thanks for contributing!

  Please describe your changes below and a general summary in the title.

-->

## Description


Since `maybeMapStatusCode` now returns input value, you will have to adjust your existing code, for example:

Replace from:

```dart
...
final statusCode = response.statusCode;
...
statusCode.maybeMapStatusCode(
    orElse: () => handleUnregisteredStatusCode(statusCode),
    isSuccess: handleSuccessStatusCode,
    ...
);
...
```

Use this instead:

```dart
...
final statusCode = response.statusCode;
...
statusCode.maybeMapStatusCode(
    orElse: handleUnregisteredStatusCode,
    isSuccess: handleSuccessStatusCode,
    ...
);
...
```

Or if you are using tear-off syntax, replace:

```dart
...
final statusCode = response.statusCode;
...
statusCode.maybeMapStatusCode(
    orElse: handleUnregisteredStatusCode,
    isSuccess: handleSuccessStatusCode,
    ...
);
...
```

With this instead:

```dart
...
final statusCode = response.statusCode;
...
statusCode.maybeMapStatusCode(
    orElse: (_) => handleUnregisteredStatusCode(),
    isSuccess: handleSuccessStatusCode,
    ...
);
...
```

## Type of Change

<!--- Please put an `x` in all the boxes that apply: -->

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [x] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [x] 🧪 Tests
- [x] 📝 Documentation
- [ ] ⚙️ CI/CD or GitHub Workflow configuration change
- [x] 📦 Dependencies update
